### PR TITLE
Clarify how to get an api key; Add listing of tags for entries when using verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # rapidblocker
-script to load rapidblock blocklist and more  
-I threw this together quickly, i give no guarantees
+script to load rapidblock blocklist and more
+I threw this together quickly, I give no guarantees
 # instructions
-Edit rapidblock.js:  
-- set instance to your instance url  
-- set api_key to an api key that has admin:read & admin:write permissions  
-Do `chmod 755 rapidblock.js`  
-Do `./rapidblock.js -h`  
+Edit rapidblock.js:
+- set instance to your instance url
+- set api_key to an api key that has admin:read & admin:write permissions
+  - To create such an api key, go to `https://<your-mastodon-server>/settings/applications`,
+    click `New application`, fill in something appropriate for the application name,
+    scroll to the bottom of the page and select `admin:read` and `admin:write`, then
+    click `SUBMIT`.
+    Once created, select your entry and use the value listed for `Your access token`.
+Do `chmod 755 rapidblock.js`
+Do `./rapidblock.js -h`

--- a/rapidblock.js
+++ b/rapidblock.js
@@ -609,7 +609,11 @@ checkRobots("https://rapidblock.org",["/blocklist.json","/blocklist.json.sig","/
                         continue
                     }
 
-                    console.log('+',domain,':',rapid.blocks[domain].reason)
+                    if (verbose) {
+                        console.log('+',domain,': [ Reason:',rapid.blocks[domain].reason, 'Tags:', rapid.blocks[domain].tags.join(', '), ']')
+                    } else {
+                        console.log('+',domain,':',rapid.blocks[domain].reason)
+                    }
                     const impact = await getBlockImpact(domain)
                     console.log(` ${impact.find(s=>s.key=="instance_followers").total} followers & ${impact.find(s=>s.key=="instance_follows").total} follows`)
                     if (jmList.find(s=>s.domain == domain)) {


### PR DESCRIPTION
Use or ignore, as you see fit 😄 

The README change is because I tried to use `Client key` (since it says api _key_) instead of the access token, then realized my mistake.

The listing of the tags is because the reason alone can be less than helpful.